### PR TITLE
Add some basic mobile / tablet styles to the Momentum homepage

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -11,6 +11,22 @@
 
 :root {
   --font-display: 'Bebas Neue Momentum', sans-serif;
+  --breakpoint-mobile: 600px;
+  --breakpoint-tablet-landscape: 992px;
+  --breakpoint-desktop: 1200px;
+}
+
+@media (max-width: 600px /* mobile */) {
+}
+@media (min-width: 992px /* tablet */) {
+}
+@media (min-width: 1200px /* desktop */) {
+}
+
+html,
+body {
+  overflow-x: hidden;
+  max-width: 100%;
 }
 
 body {
@@ -21,10 +37,6 @@ body {
   color: white;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
-
-  @media (max-width: 1024px) {
-    max-width: 100%;
-  }
 
   h1,
   h2,
@@ -93,6 +105,12 @@ header {
   width: 100%;
   height: 100vh;
 
+  @media (max-width: 992px /* tablet */) {
+    /* cap the height */
+    max-height: 80vh;
+    min-height: 40rem;
+  }
+
   display: grid;
   /*place-items: center;*/
 
@@ -115,6 +133,10 @@ header {
 
     .logo {
       width: 54rem;
+
+      @media (max-width: 992px /* tablet */) {
+        max-width: 90%;
+      }
     }
 
     .subheading {
@@ -125,6 +147,13 @@ header {
 
       -webkit-text-stroke: 9px rgb(var(--gray-700));
       paint-order: stroke fill;
+
+      @media (max-width: 992px /* tablet */) {
+        max-width: 90%;
+        font-size: 6.5vw;
+        text-align: center;
+        -webkit-text-stroke: 1vw rgb(var(--gray-700));
+      }
     }
 
     .buttons {
@@ -196,6 +225,10 @@ header {
       margin-top: calc(4vh - 1rem);
       width: 52rem;
       filter: drop-shadow(2px 4px 6px rgb(0 0 0 / 0.5));
+
+      @media (max-width: 992px /* tablet */) {
+        width: calc(100% - 2rem);
+      }
     }
   }
 
@@ -213,7 +246,7 @@ header {
   }
 
   /* WIP - Total garbage */
-  @media (max-width: 1024px) {
+  @media (min-width: 992px /* tablet */) {
     height: 100vh;
 
     .hero {
@@ -245,7 +278,7 @@ main {
     margin: 0 auto;
     max-width: 80rem; /* 1280px */
 
-    @media (max-width: 1024px) {
+    @media (max-width: 992px /* tablet */) {
       padding-inline: 2rem;
     }
   }
@@ -412,6 +445,11 @@ section#WhatIsMomentum {
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       filter: drop-shadow(0 0 8px rgb(0 0 0 / 0.5));
+
+      @media (max-width: 992px) {
+        font-size: 2.5rem;
+        margin-bottom: 1.5rem;
+      }
     }
 
     p {
@@ -461,8 +499,15 @@ section#Gamemodes {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
-
     position: relative;
+
+    @media (max-width: 992px /* tablet */) {
+      flex-wrap: nowrap;
+      flex-direction: row;
+      overflow-x: auto;
+      justify-content: flex-start;
+      align-items: stretch;
+    }
 
     > button.gamemode-button {
       display: inline-flex;
@@ -470,6 +515,13 @@ section#Gamemodes {
       align-items: center;
       gap: 0.5rem;
       padding: 0;
+
+      @media (max-width: 992px /* tablet */) {
+        flex: 0 0 auto;
+        margin-inline: 0.5rem;
+        gap: 0;
+        margin: 0;
+      }
 
       background-origin: border-box !important;
       border: none;
@@ -595,6 +647,11 @@ section#Gamemodes {
 
       &.selected {
         display: flex;
+
+        @media (max-width: 992px /* tablet */) {
+          flex-direction: column; /* Stack the video and details vertically */
+          margin: 0 1rem;
+        }
       }
 
       > video {
@@ -603,6 +660,10 @@ section#Gamemodes {
         aspect-ratio: 16 / 9;
         box-shadow: 0 0 0.75rem rgb(0 0 0 / 0.275);
         border-radius: 0.25rem;
+
+        @media (max-width: 992px /* tablet */) {
+          max-width: 100%;
+        }
       }
 
       > .details {
@@ -701,7 +762,7 @@ section#Features {
     gap: 0.75rem;
     width: 100%;
 
-    @media (max-width: 1024px) {
+    @media (max-width: 992px /* tablet */) {
       * {
         grid-column: 1 / -1 !important;
       }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -11,16 +11,6 @@
 
 :root {
   --font-display: 'Bebas Neue Momentum', sans-serif;
-  --breakpoint-mobile: 600px;
-  --breakpoint-tablet-landscape: 992px;
-  --breakpoint-desktop: 1200px;
-}
-
-@media (max-width: 600px /* mobile */) {
-}
-@media (min-width: 992px /* tablet */) {
-}
-@media (min-width: 1200px /* desktop */) {
 }
 
 html,

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -218,6 +218,12 @@ header {
             background-color: rgb(255 255 255 / 0.15);
           }
         }
+
+        @media (max-width: 768px) {
+          /* 768px is a common breakpoint for tablets */
+          margin: 0 1rem;
+          text-align: center;
+        }
       }
     }
 
@@ -245,8 +251,7 @@ header {
     mix-blend-mode: multiply;
   }
 
-  /* WIP - Total garbage */
-  @media (min-width: 992px /* tablet */) {
+  @media (max-width: 992px /* tablet */) {
     height: 100vh;
 
     .hero {
@@ -260,15 +265,17 @@ header {
         -webkit-text-stroke: 12px rgb(var(--gray-700));
       }
 
-      .buttons {
-        flex-direction: column;
-        width: 100%;
-      }
-
       .steam {
         margin-top: 2rem;
         width: 75%;
       }
+    }
+  }
+
+  @media (max-width: 600px) {
+    .buttons {
+      flex-direction: column;
+      width: 100%;
     }
   }
 }
@@ -702,10 +709,18 @@ section#Features {
   display: flex;
   flex-direction: column;
 
+  @media (max-width: 992px /* tablet */) {
+    padding: 1rem;
+  }
+
   > .header {
     display: flex;
     margin-top: 3rem;
     margin-bottom: 1.5rem;
+
+    @media (max-width: 992px /* tablet */) {
+      margin-top: 2rem;
+    }
 
     h1 {
       font-size: 4.5rem;
@@ -762,12 +777,6 @@ section#Features {
     gap: 0.75rem;
     width: 100%;
 
-    @media (max-width: 992px /* tablet */) {
-      * {
-        grid-column: 1 / -1 !important;
-      }
-    }
-
     .scroll-wrapper {
       position: relative;
       overflow: hidden;
@@ -800,6 +809,10 @@ section#Features {
         inset 0 -2.5rem 5rem -2rem rgb(255 255 255 / 0.2);
       transition: all ease-out 0.15s;
 
+      @media (max-width: 992px /* tablet */) {
+        grid-column: 1 / -1;
+      }
+
       &:hover {
         background-color: rgba(157, 219, 255, 0.125);
         box-shadow:
@@ -811,6 +824,10 @@ section#Features {
         padding: 1.75rem;
 
         h1 {
+          @media (max-width: 992px /* tablet */) {
+            text-wrap: initial;
+          }
+
           text-wrap: nowrap;
           margin-bottom: 0.5rem;
           font-size: 2.5rem;
@@ -850,6 +867,11 @@ section#Features {
       grid-row: 1 / span 2;
       margin-block: auto;
     }
+
+    @media (max-width: 992px /* tablet */) {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   .map-selector {
@@ -859,6 +881,11 @@ section#Features {
 
     .scroll-wrapper {
       height: 9rem;
+    }
+
+    @media (max-width: 992px /* tablet */) {
+      display: flex;
+      flex-direction: column;
     }
   }
 
@@ -874,6 +901,15 @@ section#Features {
       margin-block: auto;
       grid-column: span 2;
     }
+
+    @media (max-width: 992px /* tablet */) {
+      display: flex;
+      flex-direction: column;
+
+      .change {
+        margin-top: 0;
+      }
+    }
   }
 
   .multiplayer {
@@ -884,6 +920,11 @@ section#Features {
 
     .details {
       margin-block: auto;
+    }
+
+    @media (max-width: 992px /* tablet */) {
+      display: flex;
+      flex-direction: column;
     }
   }
 }

--- a/src/css/ui-chunks.css
+++ b/src/css/ui-chunks.css
@@ -138,6 +138,12 @@
       }
     }
   }
+
+  @media (max-width: 992px /* tablet */) {
+    display: flex;
+    flex-direction: column;
+    height: 12rem;
+  }
 }
 
 #MapSelector.ui-chunk {
@@ -311,6 +317,10 @@
     height: 100%;
     border-radius: 0.25rem;
     border: 1px solid rgb(255 255 255 / 0.1);
+
+    @media (max-width: 992px /* tablet */) {
+      min-height: 10vh;
+    }
 
     > * {
       position: absolute;
@@ -494,6 +504,10 @@
       -webkit-text-fill-color: transparent;
       text-shadow: none;
       filter: drop-shadow(0 1px 1px rgba(10, 40, 0, 0.5));
+    }
+
+    @media (max-width: 992px /* tablet */) {
+      margin-top: 1rem;
     }
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,9 @@
       </picture>
       <div class="hero">
         <img id="Logo" class="logo" src="/assets/images/logo.svg" alt="Momentum Mod's Titlecard Logo" />
-        <h2 class="subheading" id="Subheading">A free first-person speedrunning game built on the Source engine</h2>
+        <h2 class="subheading" id="Subheading">
+          A free first-person speedrunning game <wrb />built on the Source engine
+        </h2>
         <div class="buttons">
           <a class="dashboard" target="_blank" href="https://momentum-mod.org/dashboard"><p>Dashboard</p></a>
           <a class="donate" target="_blank" href="https://opencollective.com/momentum-mod"><p>Donate</p></a>


### PR DESCRIPTION
This PR adds some basic styles to the homepage.

I think it's in a decent state in here, there are a few minor issues that will need some design consideration after this point. They can be treated as their own separate PRs.

For example the Steam wishlist element looks bad at certain small resolutions, but I don't think there's much I can do about it.

For some reason the browser doesn't capture the fixed background on the Features section but it is still there!

![Screenshot_19-6-2024_93932_localhost](https://github.com/momentum-mod/frontpage/assets/6186871/b742954a-a3b0-48f9-93a2-846f95ef6665)
