### PR TITLE
fix(video): added autoplay attribute to autoplay in firefox

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -96,7 +96,7 @@
           <div id="GamemodeContainer" class="gamemode-container">
             <template id="GamemodeTemplate">
               <div class="active-gamemode">
-                <video id="GamemodeVideo" muted loop></video>
+                <video id="GamemodeVideo" muted loop autoplay></video>
                 <div id="GamemodeDetails" class="details"></div>
               </div>
             </template>


### PR DESCRIPTION
Closes #11 

For some reason, chrome autoplays videos with the muted attribute by default, but firefox doesn´t. 
Adding the `autoplay` attribute fixed the issue.
